### PR TITLE
Did a bit more debugging by fixing the red underline on the main.jsx file

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 
-ReactDOM.render(
+ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,


### PR DESCRIPTION
Did a bit more debugging by fixing the red underline on line 6 of the main.jsx file, by changing ReactDOM.render() to ReactDOM.createRoot(document.getElementById('root')).render(), since the former was marked as deprecated.